### PR TITLE
Update CL macros definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ kernels.c
 cmake_install.cmake
 Makefile
 CMakeCache.txt
+/cmake-build-debug/

--- a/mmid_OpenCL/src/cl_kernels/commons.c
+++ b/mmid_OpenCL/src/cl_kernels/commons.c
@@ -1,32 +1,10 @@
 #include <cstring>
 #include "commons.h"
 
-char *addDefine(const char *kernel, const char *name, const int value) {
-    int intLen = 1, count = value;
-    while (count /= 10)
-        intLen++;
-    char *x = (char *) calloc(12 + intLen + strlen(kernel) + strlen(name), sizeof(char));
-    sprintf(x, "#define %s %d\n%s", name, value, kernel);
-    return x;
-}
+extern char CL_OPTIONS[];
 
-char *addDefine(const char *kernel, const char *name, const float value) {
-    int intLen = 27, count = (int) value;
-    while (count /= 10)
-        intLen++;
-    char *x = (char *) calloc(12 + intLen + strlen(kernel) + strlen(name), sizeof(char));
-    sprintf(x, "#define %s %+14.10lf\n%s", name, value, kernel);
-    return x;
-}
-
-char *prepareKernel(int N, const cl_float dt, const int steps, const char *kern) {
-    char *tmp = addDefine(kern, "N", N), *kernel = addDefine(tmp, "dt", dt);
-    free(tmp);
-    tmp = addDefine(kernel, "steps", steps);
-    free(kernel);
-    kernel = addDefine(tmp, "INTERACT", INTERACT);
-    free(tmp);
-    return kernel;
+void prepareKernel(int N, const cl_float dt, const int steps) {
+    sprintf(CL_OPTIONS, "-Werror -DN=%d -Ddt=%.10lf -Dsteps=%d -DINTERACT=%d", N, dt, steps, INTERACT);
 }
 
 int confirm() {

--- a/mmid_OpenCL/src/cl_kernels/commons.h
+++ b/mmid_OpenCL/src/cl_kernels/commons.h
@@ -9,11 +9,7 @@
 extern int N;
 extern cl_float *m, *k, *v, *u;
 
-char *addDefine(const char *kernel, const char *name, const int value);
-
-char *addDefine(const char *kernel, const char *name, const float value);
-
-char *prepareKernel(int N, const cl_float dt, const int steps, const char *kern);
+void prepareKernel(int N, const cl_float dt, const int steps);
 
 int confirm();
 

--- a/mmid_OpenCL/src/cl_kernels/opencl_commons.c
+++ b/mmid_OpenCL/src/cl_kernels/opencl_commons.c
@@ -3,7 +3,7 @@
 
 #include "opencl_commons.h"
 
-const char *CL_OPTIONS = "-Werror";
+char CL_OPTIONS[255] = {'\0'};
 
 cl::Program
 createProgram(cl::Context &context, const char *program_data, const size_t len, std::vector<cl::Device> &devices) {

--- a/mmid_OpenCL/src/main.cpp
+++ b/mmid_OpenCL/src/main.cpp
@@ -15,7 +15,7 @@ int main(void) {
     initializeData();
     const cl_float period = 100, dt = 0.01;
     const int steps = (const int) roundf(period / dt);
-    const char *c_kernel = prepareKernel(N, dt, steps, mmid_kernel);
+    prepareKernel(N, dt, steps);
     std::vector<cl::Context> contexts = createContexts(CL_DEVICE_TYPE_ALL);
     std::cout << "Contexts generated:" << contexts.size() << std::endl << std::endl;
     // get Context devices info
@@ -37,7 +37,7 @@ int main(void) {
                             unitSize, (void *) u);
         try {
             // Compile Programs
-            cl::Program program = createProgram(*context, c_kernel, strlen(c_kernel), devices);
+            cl::Program program = createProgram(*context, mmid_kernel, mmid_kernel_len, devices);
             cl::Kernel kernel = createKernel(program);
             kernel.setArg(0, k_buffer);
             kernel.setArg(1, m_buffer);
@@ -79,7 +79,6 @@ int main(void) {
         }
     }
     releaseData();
-    free((void *) c_kernel);
     return 0;
 }
 


### PR DESCRIPTION
Removes inlining macro definitions to *.cl files,
replaced by CL_OPTION compile update.

Signed-off-by: Martin Mihálek <aenniw@gmail.com>